### PR TITLE
feat: source code modification from documentation

### DIFF
--- a/.github/workflows/build-bin-and-release.yml
+++ b/.github/workflows/build-bin-and-release.yml
@@ -1,4 +1,10 @@
-name: Release
+name: Build or Release
+
+# This action builds the binary and either:
+# - Pushes it to the release artifacts if this was a release
+# - Uploads it as an artifact if this was a pull request
+#
+# if this is a pull requests, it runs e2e test on the binary
 
 on:
   pull_request: {}
@@ -9,7 +15,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  stash:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -47,30 +53,26 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
-    needs: build
+    needs: stash
     steps:
-      - name: Check if PR
-        if: github.event_name != 'pull_request' && github.event_name != 'push'
+      - name: make sure this is not a release
+        if: github.event_name == 'release'
         run: |
-          echo "This job is only for pull_request & push"
+          echo "This job is not for releases, skipping..."
           exit 0
 
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      # - run: sudo mkdir -p /usr/local/bin
       - run: echo "/usr/local/bin" >> $GITHUB_PATH
 
-      - name: Download docs-ci Bin
+      - name: Download docs-ci binary
         uses: actions/download-artifact@v4.1.9
         with:
           name: docs-ci
           path: /usr/local/bin
       - run: chmod a+rx /usr/local/bin/docs-ci
 
-      - name: Run 1-node
-        run: docs-ci ./examples/1-node/config.json
-
-      - name: Run 2-source-code-modification
-        run: docs-ci ./examples/2-source-code-modification/config.json
+      # python runner in another job
+      - name: Run integrations as binary
+        run: EXEC_BINARY=/usr/local/bin/docs-ci make run-integrations
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           files: |
             /usr/local/bin/docs-ci
+
   test-e2e:
     runs-on: ubuntu-latest
     needs: build
@@ -69,4 +70,7 @@ jobs:
 
       - name: Run 1-node
         run: docs-ci ./examples/1-node/config.json
+
+      - name: Run 2-source-code-modification
+        run: docs-ci ./examples/2-source-code-modification/config.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pip install -r requirements.txt --break-system-packages
 
       - name: Run Python unit tests
-        run: python3 -u -m unittest tests/tests.py
+        run: make tests
 
-      - name: Verify integration test results
-        run: python3 -u -m unittest tests/integration.py
+      - name: Run integration tests (python)
+        run: make run-integrations

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Either python3 main.py or docs-ci
+EXEC_BINARY?=python3 main.py
+
 ## install: Install the binary.
 install:
 # pip install pyinstaller staticx --break-system-packages
@@ -14,6 +17,15 @@ tests:
 	@python -m unittest tests/tests.py
 	@python -m unittest tests/integration.py
 .PHONY: tests
+
+## run-integrations: Run the documentation examples within this repo
+run-integrations:
+	@echo "Running integrations as $(EXEC_BINARY)"
+	@sleep 1
+	$(EXEC_BINARY) tests/config1.json
+	$(EXEC_BINARY) examples/1-node/config.json
+	$(EXEC_BINARY) examples/2-source-code-modification/config.json
+.PHONY: run-integrations
 
 .PHONY: help
 help: Makefile

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ docs-ci <config_path>
   "debugging": false,
   "pre_cmds": ["npm install"],
   "cleanup_cmds": ["docker-compose down"],
-  "final_output_contains": "Tests passed"
 }
 ````
 
@@ -49,7 +48,7 @@ docs-ci <config_path>
 Control how your documentation code blocks are executed:
 
 ````bash
-```bash docs-ci-background docs-ci-delay-after=5
+```bash docs-ci-background docs-ci-delay-after=5 docs-ci-output-contains="Tests passed"
 # This runs in background and waits 5 seconds after completion
 npm start
 ```
@@ -62,6 +61,7 @@ npm start
   * ⏲️ `docs-ci-delay-after=N`: Wait N seconds after running commands
   * ⌛ `docs-ci-delay-per-cmd=N`: Wait N seconds before each command
   * 🌐 `docs-ci-wait-for-endpoint=http://localhost:8080/health|N`: Wait up to N seconds for the endpoint to be ready.
+  * 📜 `docs-ci-output-contains="string"`: Ensure the output contains a string at the end of the block
 
 ---
 
@@ -122,4 +122,3 @@ cat my-file.txt
 - 🎬 `pre_cmds`: Commands to run before processing markdown
 - 🧹 `cleanup_cmds`: Commands to run after processing
 - 📂 `working_dir`: Working directory for command execution
-- ✅ `final_output_contains`: Required string in final output

--- a/README.md
+++ b/README.md
@@ -62,23 +62,13 @@ npm start
   * ⌛ `docs-ci-delay-per-cmd=N`: Wait N seconds before each command
   * 🌐 `docs-ci-wait-for-endpoint=http://localhost:8080/health|N`: Wait up to N seconds for the endpoint to be ready.
   * 📜 `docs-ci-output-contains="string"`: Ensure the output contains a string at the end of the block
-
----
-
-## 🛠️ How It Works
-
-The tool processes markdown files and executes code blocks based on configuration settings. The core workflow is handled by several key components:
-
-1. 📋 **Configuration Loading** (`config_types.py`): Loads and validates the JSON configuration file
-2. 📝 **Markdown Processing** (`main.py`): Parses markdown files and processes code blocks
-3. ⚡ **Command Execution** (`execute.py`): Handles command execution and env vars
-4. 🎯 **Tag Processing** (`models.py`): Manages execution control tags
-
+  * 🚨 `docs-ci-assert-failure`: If it is expected to fail (like if the command is not supposed to run)
 
 ### 💡 Code Block Tag Examples
 
 Skip commands you've already run elsewhere: 🚫
 
+<!-- The 4 backticks is just so it wraps in githubs UI, real test are written normally with the nested part (just 3 backticks) -->
 ````bash
 ```bash docs-ci-ignore
 brew install XYZ
@@ -114,6 +104,31 @@ cat my-file.txt
 # waits 1 second
 ```
 ````
+
+Ensure the output contains a specific string: 📜
+
+````bash
+```bash docs-ci-output-contains="xyzMyOutput"
+echo xyzMyOutput
+```
+````
+
+Assert that a command fails: 🚨
+
+````bash
+```bash docs-ci-assert-failure docs-ci-output-contains="NOT THE RIGHT OUTPUT"
+echo abcMyOutput
+```
+````
+
+## 🛠️ How It Works
+
+The tool processes markdown files and executes code blocks based on configuration settings. The core workflow is handled by several key components:
+
+1. 📋 **Configuration Loading** (`config_types.py`): Loads and validates the JSON configuration file
+2. 📝 **Markdown Processing** (`main.py`): Parses markdown files and processes code blocks
+3. ⚡ **Command Execution** (`execute.py`): Handles command execution and env vars
+4. 🎯 **Tag Processing** (`models.py`): Manages execution control tags
 
 ## ⚙️ JSON Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A CI tool that brings your markdown docs to life by executing code blocks in seq
 
 ## 🏃‍♂️ Quick Start
 
+Find sample workspaces [in the `examples/` directory](./examples/).
+
 ### 📦 Installation
 
 ````bash

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Readme Runner 🚀
+# Readme Runner 🚀 &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Reecepbcups/docs-ci/blob/main/LICENSE) [![Tests](https://github.com/Reecepbcups/docs-ci/actions/workflows/test.yml/badge.svg)](https://github.com/Reecepbcups/docs-ci/actions/workflows/test.yml) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://legacy.reactjs.org/docs/how-to-contribute.html#your-first-pull-request)
 
 Your documentation is now your test suite! 🎯
 
-A CI tool that brings your markdown docs to life by executing code blocks in sequence. Run servers in the background, handle environment variables, add delays, and verify outputs - all through simple markdown tags. Perfect for ensuring your docs stay accurate and your examples actually work!
+A CI tool that brings your markdown docs to life by executing code blocks in sequence. Run servers in the background, handle environment variables, add delays, and verify outputs - all through simple markdown tags. Perfect for ensuring your docs stay accurate and your examples actually work! 📚
 
 ## 🏃‍♂️ Quick Start
 
@@ -30,6 +30,16 @@ make install
 docs-ci <config_path>
 ````
 
+### 🎨 Available tags
+  * 🚫 `docs-ci-ignore`: Skip executing this code block
+  * 🚫 `docs-ci-if-not-installed=BINARY`: Skip executing this code block if some binary is installed (e.g. node)
+  * 🔄 `docs-ci-background`: Run the command in the background
+  * ⏲️ `docs-ci-delay-after=N`: Wait N seconds after running commands
+  * ⌛ `docs-ci-delay-per-cmd=N`: Wait N seconds before each command
+  * 🌐 `docs-ci-wait-for-endpoint=http://localhost:8080/health|N`: Wait up to N seconds for the endpoint to be ready.
+  * 📜 `docs-ci-output-contains="string"`: Ensure the output contains a string at the end of the block
+  * 🚨 `docs-ci-assert-failure`: If it is expected to fail (like if the command is not supposed to run)
+
 ### 📝 Basic Example
 
 ````json
@@ -45,28 +55,7 @@ docs-ci <config_path>
 }
 ````
 
-## 🏷️ Code Block Tags
-
-Control how your documentation code blocks are executed:
-
-````bash
-```bash docs-ci-background docs-ci-delay-after=5 docs-ci-output-contains="Tests passed"
-# This runs in background and waits 5 seconds after completion
-npm start
-```
-````
-
-## 🎨 Available tags
-  * 🚫 `docs-ci-ignore`: Skip executing this code block
-  * 🚫 `docs-ci-if-not-installed=BINARY`: Skip executing this code block if some binary is installed (e.g. node)
-  * 🔄 `docs-ci-background`: Run the command in the background
-  * ⏲️ `docs-ci-delay-after=N`: Wait N seconds after running commands
-  * ⌛ `docs-ci-delay-per-cmd=N`: Wait N seconds before each command
-  * 🌐 `docs-ci-wait-for-endpoint=http://localhost:8080/health|N`: Wait up to N seconds for the endpoint to be ready.
-  * 📜 `docs-ci-output-contains="string"`: Ensure the output contains a string at the end of the block
-  * 🚨 `docs-ci-assert-failure`: If it is expected to fail (like if the command is not supposed to run)
-
-### 💡 Code Block Tag Examples
+### 💡 Code Block Tag Examples (Operations)
 
 Skip commands you've already run elsewhere: 🚫
 
@@ -77,12 +66,22 @@ brew install XYZ
 ```
 ````
 
+Skip needless installations: 🚫
+
 ````bash
 ```bash docs-ci-if-not-installed=node
 # this only runs if `node` is not found in the system
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 nvm install v21.7.3
+```
+````
+
+Ensure the output contains a specific string: 📜
+
+````bash
+```bash docs-ci-output-contains="xyzMyOutput"
+echo xyzMyOutput
 ```
 ````
 
@@ -107,14 +106,6 @@ cat my-file.txt
 ```
 ````
 
-Ensure the output contains a specific string: 📜
-
-````bash
-```bash docs-ci-output-contains="xyzMyOutput"
-echo xyzMyOutput
-```
-````
-
 Assert that a command fails: 🚨
 
 ````bash
@@ -122,6 +113,42 @@ Assert that a command fails: 🚨
 echo abcMyOutput
 ```
 ````
+
+### 💡 Code Block Tag Examples (Files)
+
+Create a new file from content: 📝
+
+<!-- yes, the typo is meant to be here -->
+```html title=example.html docs-ci-reset-file
+<html>
+    <head>
+        <title>My Titlee</title>
+    </head>
+</html>
+```
+
+Replace the typo'ed line:
+
+```html title=example.html docs-ci-line-replace=3
+        <title>My Title</title>
+```
+
+Add new content
+
+```html title=example.html docs-ci-line-insert=4
+    <body>
+        <h1>My Header</h1>
+        <p>1 paragraph</p>
+        <p>2 paragraph</p>
+    </body>
+```
+
+Replace multiple lines
+
+```html title=example.html docs-ci-line-replace=7-9
+        <p>First paragraph</p>
+        <p>Second paragraph</p>
+```
 
 ## 🛠️ How It Works
 
@@ -131,6 +158,10 @@ The tool processes markdown files and executes code blocks based on configuratio
 2. 📝 **Markdown Processing** (`main.py`): Parses markdown files and processes code blocks
 3. ⚡ **Command Execution** (`execute.py`): Handles command execution and env vars
 4. 🎯 **Tag Processing** (`models.py`): Manages execution control tags
+
+Control how your documentation code blocks are executed with no code, just code block tags. 🏷️
+
+
 
 ## ⚙️ JSON Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ make install
 # make sure to update 1) the version in the URL 2) the config path to run against
 - name: Readme Runner
     run: |
-    sudo wget -O /usr/local/bin/docs-ci https://github.com/Reecepbcups/docs-ci/releases/download/v0.2.0/docs-ci
+    sudo wget -O /usr/local/bin/docs-ci https://github.com/Reecepbcups/docs-ci/releases/download/v0.3.0/docs-ci
     sudo chmod +x /usr/local/bin/docs-ci
     docs-ci .github/workflows/config.json
 ````
@@ -27,7 +27,9 @@ make install
 ### 🎮 Usage
 
 ````bash
-docs-ci <config_path>
+docs-ci <config_path | config_json>
+# e.g. docs-ci .github/workflows/config.json
+# e.g. docs-ci '{"paths": ["docs/README.md"],"working_dir": "docs/","cleanup_cmds": ["kill -9 $(lsof -t -i:3000)"]}'
 ````
 
 ### 🎨 Available tags
@@ -170,3 +172,8 @@ Control how your documentation code blocks are executed with no code, just code 
 - 🎬 `pre_cmds`: Commands to run before processing markdown
 - 🧹 `cleanup_cmds`: Commands to run after processing
 - 📂 `working_dir`: Working directory for command execution
+
+## 🚧 Limitations
+
+- Not yet tested on MacOS or Windows WSL
+- Multi-line commands in docs are not supported yet

--- a/config_types.py
+++ b/config_types.py
@@ -4,9 +4,10 @@ import subprocess
 from typing import Dict, List
 
  # https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers
-ShellLanguages = ["shell", "bash", "sh", "zsh", "ksh"] # if it is not in here then it is likely a source ode
+ScriptingLanguages = ["shell", "bash", "sh", "zsh", "ksh"] # if it is not in here then it is likely a source ode
 
 class Config:
+    config_version = "v0.0.1" # future proofing
     paths: List[str] = [] # this will be loaded with the prefix of the absolute path of the repo
     env_vars: Dict[str, str] = {}
     pre_cmds: List[str] = []
@@ -14,7 +15,7 @@ class Config:
     only_run_bash: bool = True
     ignore_commands: List[str] = []
     supported_file_extensions = ["md", "mdx"]
-    followed_languages = ShellLanguages
+    followed_languages = ScriptingLanguages
     working_dir: str | None = None
     debugging = False
 

--- a/config_types.py
+++ b/config_types.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 from typing import Dict, List
 
+ # https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers
+ShellLanguages = ["shell", "bash", "sh", "zsh", "ksh"] # if it is not in here then it is likely a source ode
 
 class Config:
     paths: List[str] = [] # this will be loaded with the prefix of the absolute path of the repo
@@ -13,7 +15,7 @@ class Config:
     ignore_commands: List[str] = []
     final_output_contains: str = ''
     supported_file_extensions = ["md", "mdx"]
-    followed_languages = ["shell", "bash", "sh", "zsh","ksh"] # https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers
+    followed_languages = ShellLanguages
     working_dir: str | None = None
     debugging = False
 
@@ -83,6 +85,11 @@ class Config:
     @staticmethod
     def load_from_file(absolute_path: str) -> "Config":
         with open(absolute_path) as f:
-            return Config.from_json(json.load(f))
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                print(f"Invalid JSON in file: {absolute_path}, make sure you reference the JSON config file & not the README")
+                exit(1)
+            return Config.from_json(data)
 
 

--- a/config_types.py
+++ b/config_types.py
@@ -13,18 +13,16 @@ class Config:
     cleanup_cmds: List[str] = []
     only_run_bash: bool = True
     ignore_commands: List[str] = []
-    final_output_contains: str = ''
     supported_file_extensions = ["md", "mdx"]
     followed_languages = ShellLanguages
     working_dir: str | None = None
     debugging = False
 
-    def __init__(self, paths: List[str], env_var: Dict[str, str], cleanup_cmds: List[str], pre_cmds: List[str] = [], final_output_contains: str = ''):
+    def __init__(self, paths: List[str], env_var: Dict[str, str], cleanup_cmds: List[str], pre_cmds: List[str] = []):
         self.paths = paths
         self.env_vars = env_var
         self.cleanup_cmds = cleanup_cmds
         self.pre_cmds = pre_cmds
-        self.final_output_contains = final_output_contains
 
     def iterate_paths(self):
         for path in self.paths:
@@ -67,7 +65,7 @@ class Config:
 
     @classmethod
     def from_json(cls, json: Dict) -> "Config":
-        c = Config(json['paths'], json.get('env_vars', {}), json.get('cleanup_cmds', []), json.get('pre_cmds', []), json.get('final_output_contains', ''))
+        c = Config(json['paths'], json.get('env_vars', {}), json.get('cleanup_cmds', []), json.get('pre_cmds', []))
         c.working_dir = json.get('working_dir', None)
         c.debugging = json.get('debugging', False)
         return c
@@ -79,7 +77,6 @@ class Config:
             'cleanup_cmds': self.cleanup_cmds,
             'pre_cmds': self.pre_cmds,
             'working_dir': self.working_dir,
-            'final_output_contains': self.final_output_contains
         }
 
     @staticmethod

--- a/examples/1-node/README.md
+++ b/examples/1-node/README.md
@@ -30,6 +30,6 @@ npx tsc
 node dist/app.js
 ```
 
-```bash
+```bash docs-ci-output-contains="Hello World!"
 curl -X GET http://localhost:3000 --no-progress-meter
 ```

--- a/examples/1-node/config.json
+++ b/examples/1-node/config.json
@@ -9,5 +9,5 @@
     "cleanup_cmds": [
       "kill -9 $(lsof -t -i:3000)"
     ],
-    "final_output_contains": "Hello World"
+    "final_output_contains": ""
   }

--- a/examples/1-node/config.json
+++ b/examples/1-node/config.json
@@ -8,6 +8,5 @@
     "debugging": true,
     "cleanup_cmds": [
       "kill -9 $(lsof -t -i:3000)"
-    ],
-    "final_output_contains": ""
+    ]
   }

--- a/examples/2-source-code-modification/.gitignore
+++ b/examples/2-source-code-modification/.gitignore
@@ -1,0 +1,2 @@
+example.py
+example.json

--- a/examples/2-source-code-modification/.gitignore
+++ b/examples/2-source-code-modification/.gitignore
@@ -1,2 +1,3 @@
 example.py
 example.json
+example.html

--- a/examples/2-source-code-modification/README.md
+++ b/examples/2-source-code-modification/README.md
@@ -1,22 +1,24 @@
 # Source Code Modification
 
-How to document source code changes into real files for verification.
+Modifying underlying documents with inserting, replacing, or resetting files.
 
 ## Steps
 
 ```bash docs-ci-ignore
-cd ./examples/2-source-code-impl
+cd ./examples/2-source-code-modification
 ```
 
-Create a new file called `example.json` and input the following contents
+Create a new file called `example.json` and input the following contents.
+- If the file does not exist, it will be created.
+- If the file exists, it will be overwritten due to `docs-ci-reset-file`
 
-```json title=example.json docs-ci-insert-at-line=0
+```json title=example.json docs-ci-reset-file
 {
     "some_key": "My Value"
 }
 ```
 
-```python title=example.py docs-ci-insert-at-line=0
+```python title=example.py docs-ci-reset-file
 import json
 
 def main():
@@ -30,10 +32,87 @@ if __name__ == "__main__":
     main()
 ```
 
-Run the example, the some_key value is printed. Since this is the last command the output is checked
+Run the example, the `some_key` value is printed & output is verified.
 
 ```bash docs-ci-output-contains="My Value"
 python3 example.py
 ```
 
-The files are then automatically removed after with the config.json
+---
+
+# Replacements and modifications
+
+### Create a new website
+
+```html title=example.html docs-ci-reset-file
+<html>
+    <head>
+        <title>My Titlee</title>
+    </head>
+</html>
+```
+
+### Fix the typo at line 3
+
+```html title=example.html docs-ci-line-replace=3
+        <title>My Title</title>
+```
+
+### Add new content at line 4
+
+Add main content after the head tag
+
+```html title=example.html docs-ci-line-insert=4
+    <body>
+        <h1>My Header</h1>
+        <p>1 paragraph</p>
+        <p>2 paragraph</p>
+    </body>
+```
+
+### Replace multiple lines
+
+Fix the paragraphs to spell it instead over multiple lines
+
+```html title=example.html docs-ci-line-replace=7-9
+        <p>First paragraph</p>
+        <p>Second paragraph</p>
+```
+
+
+### Try ot replace non existent lines
+
+If you try to replace a line too far out of bounds, it will just append
+
+```html title=example.html docs-ci-line-replace=44
+<!-- example comment at the end of the file -->
+```
+
+Negative insert's will wrap around the length, allowing you to append from the end
+
+```html title=example.html docs-ci-line-insert=-1
+<!-- Even further comment using -1 as insert -->
+```
+
+### Verify it matches expected
+
+Verify against a hardcoded check *(this is just for internal verification)*
+
+```bash
+cat example.html | diff - expected.html
+```
+
+These files can be automatically removed if your config sets to `rm` in the cleanup section. (regex supported)
+
+```json
+{
+    "paths": [
+      "examples/2-source-code-modification/README.md"
+    ],
+    "cleanup_cmds": [
+      "rm examples/2-source-code-modification/example.py",
+      "rm examples/2-source-code-modification/example.json"
+      "rm examples/2-source-code-modification/example.html"
+    ],
+  }
+```

--- a/examples/2-source-code-modification/README.md
+++ b/examples/2-source-code-modification/README.md
@@ -1,0 +1,39 @@
+# Source Code Modification
+
+How to document source code changes into real files for verification.
+
+## Steps
+
+```bash docs-ci-ignore
+cd ./examples/2-source-code-impl
+```
+
+Create a new file called `example.json` and input the following contents
+
+```json title=example.json docs-ci-insert-at-line=0
+{
+    "some_key": "My Value"
+}
+```
+
+```python title=example.py docs-ci-insert-at-line=0
+import json
+
+def main():
+    with open('example.json', 'r') as f:
+        lines = f.readlines()
+        data = json.loads(''.join(lines))
+
+    print(data['some_key'])
+
+if __name__ == "__main__":
+    main()
+```
+
+Run the example, the some_key value is printed. Since this is the last command the output is checked
+
+```bash
+python3 example.py
+```
+
+The files are then automatically removed after with the config.json

--- a/examples/2-source-code-modification/README.md
+++ b/examples/2-source-code-modification/README.md
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
 Run the example, the some_key value is printed. Since this is the last command the output is checked
 
-```bash
+```bash docs-ci-output-contains="My Value"
 python3 example.py
 ```
 

--- a/examples/2-source-code-modification/config.json
+++ b/examples/2-source-code-modification/config.json
@@ -9,6 +9,5 @@
     ],
     "env_vars": {},
     "pre_cmds": [],
-    "debugging": false,
-    "final_output_contains": "My Value"
+    "debugging": true
   }

--- a/examples/2-source-code-modification/config.json
+++ b/examples/2-source-code-modification/config.json
@@ -3,11 +3,8 @@
       "examples/2-source-code-modification/README.md"
     ],
     "working_dir": "examples/2-source-code-modification",
-    "cleanup_cmds": [
-      "rm examples/2-source-code-modification/example.py",
-      "rm examples/2-source-code-modification/example.json"
-    ],
+    "cleanup_cmds": [],
     "env_vars": {},
     "pre_cmds": [],
-    "debugging": true
+    "debugging": false
   }

--- a/examples/2-source-code-modification/config.json
+++ b/examples/2-source-code-modification/config.json
@@ -1,0 +1,14 @@
+{
+    "paths": [
+      "examples/2-source-code-modification/README.md"
+    ],
+    "working_dir": "examples/2-source-code-modification",
+    "cleanup_cmds": [
+      "rm examples/2-source-code-modification/example.py",
+      "rm examples/2-source-code-modification/example.json"
+    ],
+    "env_vars": {},
+    "pre_cmds": [],
+    "debugging": false,
+    "final_output_contains": "My Value"
+  }

--- a/examples/2-source-code-modification/expected.html
+++ b/examples/2-source-code-modification/expected.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+        <title>My Title</title>
+    </head>
+    <body>
+        <h1>My Header</h1>
+        <p>First paragraph</p>
+        <p>Second paragraph</p>
+    </body>
+</html>
+<!-- example comment at the end of the file -->
+<!-- Even further comment using -1 as insert -->

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+## How to run
+
+```bash
+make run-integrations
+```
+
+## Examples
+
+* [1-node](./1-node)
+    - A NodeJS express server verifier
+    - Installs node if you do not have it already as `node`.
+    - Verifies output via curl after a delay from startup
+* [2-source-code-modification](./2-source-code-modification)
+    - Creates a JSON file and reads it back in a generated python file
+    - Build a HTML website. Replace typo line(s), insert new content, reset files to default.

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from typing import Dict, Generator, List, Literal, Optional, Tuple
 
 import requests
 
-from config_types import Config
+from config_types import Config, ScriptingLanguages
 from execute import execute_substitution_commands
 from models import Endpoint, Tags, handle_http_polling_input
 
@@ -56,6 +56,13 @@ def main():
 
     cfg_input = sys.argv[1]
 
+    if os.path.isdir(cfg_input):
+        # TODO: search through all json files in dir & find ones content whose matches the expected layout
+        cfg_input = os.path.join(cfg_input, 'config.json')
+        if not os.path.exists(cfg_input):
+            print(f"Error: config.json not found in directory: {sys.argv[1]}")
+            sys.exit(1)
+
     if os.path.isfile(cfg_input):
         config: Config = Config.load_from_file(cfg_input)
     else:
@@ -84,6 +91,8 @@ class DocsValue:
     # when the file does, it will insert the content at the line number. if the file is empty, it will always insert at the start (idx 0)
     file_name: str | None = None # may also be referenced as `title` in enum
     insert_at_line: int | None = None
+    replace_lines: Tuple[int, int | None] | None = None # start and optional end
+    file_reset: bool = False
 
     # returns a string or bool. if bool is true, success, if false, failed
     def endpoint_poll_if_applicable(self, poll_speed: float = 1.0) -> Generator[Tuple[bool, str], None, None]:
@@ -103,25 +112,46 @@ class DocsValue:
             attempt += 1
 
     # handle_file_content returns True if we handled a file, False if we did not
+    # NOTE: we handle this as a human reads it, lines start at ONE (1), not zero
     def handle_file_content(self, config: Config) -> bool:
         if not self.file_name:
             return False
 
         file_path = os.path.join(config.working_dir, self.file_name) if config.working_dir else self.file_name
 
-        if not os.path.exists(file_path):
+        if not os.path.exists(file_path) or self.file_reset:
+            if config.debugging:
+                print(f"Refreshing file: {file_path}", "since file reset is on" if self.file_reset else "")
             with open(file_path, 'w') as f:
-             f.write(self.content)
-        else:
-            # read and insert at the given line
-            with open(file_path, 'r') as f:
-                lines = f.readlines()
+                f.write(self.content)
 
-            if self.insert_at_line:
-                lines.insert(self.insert_at_line, self.content)
+        # read and insert at the given line
+        with open(file_path, 'r') as f:
+            lines = f.readlines()
 
-            with open(file_path, 'w') as f:
-                f.write(''.join(lines))
+        if self.insert_at_line:
+            # if insert at line is negative, then it is relative to the end of the file
+            insert_line = self.insert_at_line if self.insert_at_line > 0 else len(lines) + self.insert_at_line + 1
+            lines.insert(insert_line, self.content)
+
+        if self.replace_lines:
+            start, end = self.replace_lines
+            # line based, not index :)
+            start = start - 1 if start > 0 else 0
+            end = end - 1 if end and end > 0 else None
+            if end:
+                if end > len(lines):
+                    end = len(lines) - 1
+
+                lines[start:end] = self.content
+            else:
+                if start > len(lines):
+                    lines.append(self.content)
+                else:
+                    lines[start] = self.content
+
+        with open(file_path, 'w') as f:
+            f.write(''.join(lines))
 
         return True
 
@@ -328,6 +358,13 @@ def process_language_parts(language_parts):
     raw_tags = language_parts[1:]
     processed_tags = []
 
+    for tag in raw_tags:
+        if Tags.TAGS_PREFIX() not in tag: continue
+        if '=' in tag: tag = tag.split('=')[0]
+
+        if not Tags.is_valid(tag):
+            raise ValueError(f"Invalid tag found in your documentation: {tag}. Check the release notes for renamed tags")
+
     i = 0
     while i < len(raw_tags):
         current_tag = raw_tags[i]
@@ -398,7 +435,10 @@ def parse_markdown_code_blocks(config: Config | None, content: str) -> List[Docs
         if config is not None:
             ignored = ignored or language not in config.followed_languages
 
-        content = str(block_content).strip()
+        # we can not strip content if it's language based, only for scripts
+        content = str(block_content)
+        if language in ScriptingLanguages:
+            content = content.strip()
 
         value = DocsValue(
             language=language,
@@ -416,6 +456,8 @@ def parse_markdown_code_blocks(config: Config | None, content: str) -> List[Docs
             # file specific
             file_name=extract_tag_value(tags, Tags.TITLE(), default=None),
             insert_at_line=extract_tag_value(tags, Tags.INSERT_AT_LINE(), default=None, converter=int),
+            replace_lines=extract_tag_value(tags, Tags.REPLACE_AT_LINE(), default=None, converter=replace_at_line_converter),
+            file_reset=(Tags.RESET_FILE() in tags),
         )
 
         # using regex, remove any sections of code that start with a comment '#' and end with a new line '\n', this info is not needed.
@@ -439,7 +481,13 @@ def parse_markdown_code_blocks(config: Config | None, content: str) -> List[Docs
 
     return results
 
-
+# input could be just a number ex: 3
+# or a range of numbers; 2-4
+def replace_at_line_converter(value: str) -> Tuple[int, int | None]:
+    if '-' in value:
+        start, end = value.split('-')
+        return int(start), int(end)
+    return int(value), None
 
 def parse_env(command: str) -> Dict[str, str]:
     """

--- a/models.py
+++ b/models.py
@@ -10,9 +10,10 @@ class Tags(Enum):
     CMD_DELAY = 'docs-ci-delay-per-cmd'
     HTTP_POLLING = 'docs-ci-wait-for-endpoint'
     IGNORE_IF_INSTALLED = 'docs-ci-if-not-installed'
+    OUTPUT_CONTAINS = 'docs-ci-output-contains'
 
     # file related
-    FILE_NAME = 'title' # maybe we also alias with a docs-ci-title or -filename or something?
+    TITLE = 'title' # maybe we also alias with a docs-ci-title or -filename or something?
     INSERT_AT_LINE = 'docs-ci-insert-at-line'
 
     def __str__(self):

--- a/models.py
+++ b/models.py
@@ -11,6 +11,10 @@ class Tags(Enum):
     HTTP_POLLING = 'docs-ci-wait-for-endpoint'
     IGNORE_IF_INSTALLED = 'docs-ci-if-not-installed'
 
+    # file related
+    FILE_NAME = 'title' # maybe we also alias with a docs-ci-title or -filename or something?
+    INSERT_AT_LINE = 'docs-ci-insert-at-line'
+
     def __str__(self):
         return self.value
 

--- a/models.py
+++ b/models.py
@@ -11,6 +11,7 @@ class Tags(Enum):
     HTTP_POLLING = 'docs-ci-wait-for-endpoint'
     IGNORE_IF_INSTALLED = 'docs-ci-if-not-installed'
     OUTPUT_CONTAINS = 'docs-ci-output-contains'
+    ASSERT_FAILURE = 'docs-ci-assert-failure'
 
     # file related
     TITLE = 'title' # maybe we also alias with a docs-ci-title or -filename or something?

--- a/models.py
+++ b/models.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 
 class Tags(Enum):
+    TAGS_PREFIX = 'docs-ci-'
+
     IGNORE = 'docs-ci-ignore'
     BACKGROUND = 'docs-ci-background'
     POST_DELAY = 'docs-ci-delay-after'
@@ -15,13 +17,26 @@ class Tags(Enum):
 
     # file related
     TITLE = 'title' # maybe we also alias with a docs-ci-title or -filename or something?
-    INSERT_AT_LINE = 'docs-ci-insert-at-line'
+    INSERT_AT_LINE = 'docs-ci-line-insert'
+    REPLACE_AT_LINE= 'docs-ci-line-replace' # docs-ci-line-replace=2-4 or docs-ci-line-replace=2 works
+    RESET_FILE = 'docs-ci-reset-file'
 
     def __str__(self):
         return self.value
 
     def __call__(self):
         return self.value
+
+    @staticmethod
+    def from_str(tag: str) -> 'Tags':
+        return Tags(tag)
+
+    @staticmethod
+    def is_valid(tag: str) -> bool:
+        for member in Tags:
+            if member.value == tag:
+                return True
+        return False
 
 @dataclass
 class Endpoint:

--- a/tests/README1.md
+++ b/tests/README1.md
@@ -4,6 +4,6 @@
 this is ignored
 ```
 
-```bash
+```bash docs-ci-output-contains="abcMyOutput"
 echo abcMyOutput
 ```

--- a/tests/README2.md
+++ b/tests/README2.md
@@ -6,11 +6,11 @@ this is a duplicate of the ../README1.md file to simulate
 this is ignored
 ```
 
-```bash
+```bash docs-ci-output-contains="xyzMyOutput"
 echo xyzMyOutput
 ```
 
-```bash
+```bash docs-ci-output-contains="abcMyOutput"
 echo abcMyOutput
 ```
 

--- a/tests/README2.md
+++ b/tests/README2.md
@@ -14,4 +14,8 @@ echo xyzMyOutput
 echo abcMyOutput
 ```
 
+```bash docs-ci-assert-failure docs-ci-output-contains="NOT THE RIGHT OUTPUT"
+echo abcMyOutput
+```
+
 

--- a/tests/config1.json
+++ b/tests/config1.json
@@ -5,5 +5,6 @@
   ],
   "env_vars": {},
   "pre_cmds": [],
-  "cleanup_cmds": []
+  "cleanup_cmds": [],
+  "debugging": false
 }

--- a/tests/config1.json
+++ b/tests/config1.json
@@ -1,9 +1,9 @@
 {
   "paths": [
-    "tests/README1.md"
+    "tests/README1.md",
+    "tests/README2.md"
   ],
   "env_vars": {},
   "pre_cmds": [],
-  "cleanup_cmds": [],
-  "final_output_contains": "abcMyOutput"
+  "cleanup_cmds": []
 }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -27,6 +27,10 @@ class TestSomething(unittest.TestCase):
         dv = parse_markdown_code_blocks(config=None, content='```bash docs-ci-output-contains="My Multi Word Value"\npython3 example.py```')[0]
         self.assertEqual(dv.output_contains, "My Multi Word Value")
 
+        dv = parse_markdown_code_blocks(config=None, content='```bash docs-ci-output-contains="My Multi Word Value" docs-ci-delay-after=123\npython3 example.py```')[0]
+        self.assertEqual(dv.output_contains, "My Multi Word Value")
+        self.assertEqual(dv.post_delay, 123)
+
 
     def test_extract_tag_value(self):
         # this is after process_language_parts, we just input good values here for verification

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -45,14 +45,10 @@ class TestSomething(unittest.TestCase):
         err = do_logic(Config.load_from_file(os.path.join(curr_dir, "config1.json")))
         self.assertEqual(err, None, err)
 
-    # def test_config_bad_output_check(self):
-    #     err = do_logic(Config.from_json({"paths":["tests/README1.md"],"env_vars": {},"pre_cmds": [],"cleanup_cmds": [],"final_output_contains": "incorrectValueNotFoundHere"}))
-    #     self.assertNotEqual(err, None, err)
-
-    # def test_multiple_paths_same_output(self):
-    #     # if you use multiple paths here, you HAVE to have the same outputs to actually verify. Good for duplicate documentation places that should match up exactly
-    #     err = do_logic(Config.from_json({"paths":["tests/README1.md", "tests/README2.md"],"env_vars": {},"pre_cmds": [],"cleanup_cmds": [],"final_output_contains": "abcMyOutput"}))
-    #     self.assertEqual(err, None, err)
+    def test_multiple_paths_same_output(self):
+        # if you use multiple paths here, you HAVE to have the same outputs to actually verify. Good for duplicate documentation places that should match up exactly
+        err = do_logic(Config.from_json({"paths":["tests/README1.md", "tests/README2.md"],"env_vars": {},"pre_cmds": [],"cleanup_cmds": []}))
+        self.assertEqual(err, None, err)
 
     def test_execute_substitution_commands(self):
         # nothing to exec, leave as is


### PR DESCRIPTION
closes  #9 

## Changes
- config `final_output_contains` no longer exists, replaced with `docs-ci-output-contains="MY VALUE"` in codeblock tags
- tag: `docs-ci-assert-failure` if you expect a codeblock to fail execution
- source code can now be inserted or created from codeblocks
- you can now run your config.json by just specifying the directory (config.json assumed)
- Replace multiple lines, reset files
- Tag validation: if a docs-ci- tag is not real, it will error for you