### PR TITLE
feat: --keep-running

### DIFF
--- a/docci.go
+++ b/docci.go
@@ -9,6 +9,7 @@ import (
 	"github.com/reecepbcups/docci/executor"
 	"github.com/reecepbcups/docci/logger"
 	"github.com/reecepbcups/docci/parser"
+	"github.com/reecepbcups/docci/types"
 )
 
 // DocciResult contains the complete result of running a docci file
@@ -23,11 +24,14 @@ type DocciResult struct {
 // RunDocciFile executes all the logic for processing a docci markdown file
 // This function encapsulates the complete workflow: parse -> build -> execute -> validate
 func RunDocciFile(filePath string) DocciResult {
-	return RunDocciFileWithOptions(filePath, false)
+	return RunDocciFileWithOptions(filePath, types.DocciOpts{
+		HideBackgroundLogs: false,
+		KeepRunning:        false,
+	})
 }
 
 // RunDocciFileWithOptions executes all the logic for processing a docci markdown file with options
-func RunDocciFileWithOptions(filePath string, hideBackgroundLogs bool) DocciResult {
+func RunDocciFileWithOptions(filePath string, opts types.DocciOpts) DocciResult {
 	log := logger.GetLogger()
 
 	// Read the file into a string
@@ -58,7 +62,10 @@ func RunDocciFileWithOptions(filePath string, hideBackgroundLogs bool) DocciResu
 
 	// Build executable script with validation markers
 	log.Debug("Building executable script")
-	script, validationMap, assertFailureMap := parser.BuildExecutableScriptWithOptions(blocks, hideBackgroundLogs)
+	script, validationMap, assertFailureMap := parser.BuildExecutableScriptWithOptions(blocks, types.DocciOpts{
+		HideBackgroundLogs: hideBackgroundLogs,
+		KeepRunning:        keepRunning,
+	})
 
 	// Execute the script
 	log.Debug("Executing script")
@@ -160,11 +167,14 @@ func RunDocciCommand(filePath string) {
 
 // RunDocciFiles merges multiple markdown files and executes them as one
 func RunDocciFiles(filePaths []string) DocciResult {
-	return RunDocciFilesWithOptions(filePaths, false)
+	return RunDocciFilesWithOptions(filePaths, types.DocciOpts{
+		HideBackgroundLogs: false,
+		KeepRunning:        false,
+	})
 }
 
 // RunDocciFilesWithOptions merges multiple markdown files and executes them as one with options
-func RunDocciFilesWithOptions(filePaths []string, hideBackgroundLogs bool) DocciResult {
+func RunDocciFilesWithOptions(filePaths []string, opts types.DocciOpts) DocciResult {
 	log := logger.GetLogger()
 
 	log.Debugf("Merging %d markdown files", len(filePaths))
@@ -212,7 +222,10 @@ func RunDocciFilesWithOptions(filePaths []string, hideBackgroundLogs bool) Docci
 
 	// Build executable script with validation markers
 	log.Debug("Building executable script from merged blocks")
-	script, validationMap, assertFailureMap := parser.BuildExecutableScriptWithOptions(allBlocks, hideBackgroundLogs)
+	script, validationMap, assertFailureMap := parser.BuildExecutableScriptWithOptions(allBlocks, types.DocciOpts{
+		HideBackgroundLogs: hideBackgroundLogs,
+		KeepRunning:        keepRunning,
+	})
 
 	// Execute the script
 	log.Debug("Executing merged script")

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/reecepbcups/docci/logger"
 	"github.com/reecepbcups/docci/parser"
+	"github.com/reecepbcups/docci/types"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ var (
 	cleanupCommands    []string
 	hideBackgroundLogs bool
 	workingDir         string
+	keepRunning        bool
 )
 
 var rootCmd = &cobra.Command{
@@ -85,11 +87,17 @@ Multiple files can be specified separated by commas.`,
 		}
 
 		// Run the docci command with merged files or single file
+
+		opts := types.DocciOpts{
+			HideBackgroundLogs: hideBackgroundLogs,
+			KeepRunning:        keepRunning,
+		}
+
 		var result DocciResult
 		if len(filePaths) == 1 {
-			result = RunDocciFileWithOptions(filePaths[0], hideBackgroundLogs)
+			result = RunDocciFileWithOptions(filePaths[0], opts)
 		} else {
-			result = RunDocciFilesWithOptions(filePaths, hideBackgroundLogs)
+			result = RunDocciFilesWithOptions(filePaths, opts)
 		}
 
 		// Command output is already printed by executor in real-time with filtering
@@ -267,6 +275,7 @@ func init() {
 	runCmd.Flags().StringSliceVar(&cleanupCommands, "cleanup-commands", []string{}, "commands to run after execution completes")
 	runCmd.Flags().BoolVar(&hideBackgroundLogs, "hide-background-logs", false, "hide background process logs from output")
 	runCmd.Flags().StringVar(&workingDir, "working-dir", "", "change working directory before running commands")
+	runCmd.Flags().BoolVar(&keepRunning, "keep-running", false, "keep containers running after execution with infinite sleep")
 }
 
 func runPreCommands(commands []string) error {

--- a/readme_test.go
+++ b/readme_test.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/reecepbcups/docci/types"
 )
 
 func TestReadme(t *testing.T) {
@@ -28,7 +30,10 @@ func TestReadme(t *testing.T) {
 	defer os.Remove(tempFile)
 
 	// Run docci on the processed README
-	result := RunDocciFileWithOptions(tempFile, true) // hide background logs for cleaner test output
+	result := RunDocciFileWithOptions(tempFile, types.DocciOpts{
+		HideBackgroundLogs: true,
+		KeepRunning:        false,
+	}) // hide background logs for cleaner test output
 
 	// Check if the execution was successful
 	if !result.Success {

--- a/types/docci.go
+++ b/types/docci.go
@@ -1,0 +1,6 @@
+package types
+
+type DocciOpts struct {
+	HideBackgroundLogs bool
+	KeepRunning        bool
+}


### PR DESCRIPTION
## Summary

Sometimes it is nice to actually debug after the process finishes (like endpoints)

So delays background tasks from exiting first