### PR TITLE
fix: ignore errors for pre/post cmds + absolute readme file path gen

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,9 +81,7 @@ Multiple files can be specified separated by commas.`,
 		// Run pre-commands if provided
 		if len(preCommands) > 0 {
 			log.Debug("Running pre-commands")
-			if err := runPreCommands(preCommands); err != nil {
-				return fmt.Errorf("pre-command failed: %w", err)
-			}
+			runPreCommands(preCommands)
 		}
 
 		// Run the docci command with merged files or single file
@@ -291,11 +289,11 @@ func runPreCommands(commands []string) error {
 
 		// Run the command
 		if err := cmd.Run(); err != nil {
-			log.Errorf("Error running pre-command '%s': %v", command, err)
-			return fmt.Errorf("pre-command '%s' failed: %w", command, err)
+			log.Warnf("Pre-command '%s' failed (ignoring): %v", command, err)
+			// Continue with other pre-commands even if one fails
 		}
 	}
-	log.Info("Pre-commands completed successfully")
+	log.Info("Pre-commands completed")
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/reecepbcups/docci/logger"
@@ -53,6 +54,15 @@ Multiple files can be specified separated by commas.`,
 
 		// Parse multiple files if provided
 		filePaths := parseFileList(input)
+
+		// Convert relative paths to absolute paths
+		for i, filePath := range filePaths {
+			absPath, err := filepath.Abs(filePath)
+			if err != nil {
+				return fmt.Errorf("failed to resolve absolute path for %s: %w", filePath, err)
+			}
+			filePaths[i] = absPath
+		}
 
 		// Check if all files exist
 		for _, filePath := range filePaths {


### PR DESCRIPTION
[bb4511e](https://github.com/Reecepbcups/docci/pull/61/commits/bb4511eda44fb52644fa440b5fb793b06a9b78aa) was found when I ran `docci run README.md` in another repo and the test from this repo ran.

```
Run docci run README.md --cleanup-commands="killall anvil"
  docci run README.md --cleanup-commands="killall anvil"
  shell: /usr/bin/bash -e {0}
  env:
    GO_VERSION: 1.23.7
    DEBUGGING: true
level=info msg="Running docci on file: README.md"
     Executing CMD: echo xyzMyOutput
     Executing CMD: trap - DEBUG
xyzMyOutput
Started background process 2 with PID 6241
Waiting for endpoint http://localhost:3000/health to be ready...
Endpoint not ready yet, retrying in 1 second... (elapsed: 0s)
Endpoint not ready yet, retrying in 1 second... (elapsed: 1s)
Endpoint not ready yet, retrying in 1 second... (elapsed: 2s)
Endpoint not ready yet, retrying in 1 second... (elapsed: 3s)
```