### PR TITLE
feat: kill background process code tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ docci version
 ### 🎨 Operation tags
   * 🛑 `docci-ignore`: Skip executing this code block
   * 🔄 `docci-background`: Run the command in the background
+  * 💀 `docci-background-kill=N`: Kill a previously started background process by index (1-based)
   * 🚫 `docci-if-not-installed=BINARY`: Skip execution if some binary is installed (e.g. node)
   * ⏲️ `docci-delay-before=N`: Wait N seconds before running any commands in the block
   * ⏲️ `docci-delay-after=N`: Wait N seconds after running all commands in the block
@@ -131,7 +132,7 @@ echo "Imagine a cURL request with API_KEY here"
 ```
 ````
 
-And cleanup demo server if running in the background:
+Cleanup demo server if running in the background:
 
 ````bash
 ```bash

--- a/docci_test.go
+++ b/docci_test.go
@@ -39,6 +39,9 @@ var TestExpectations = map[string]TestExpectation{
 	"assert-failure-unexpected-success.md": {
 		ExpectedInStderr: "Expected script to fail with non-zero exit code due to docci-assert-failure tag, but it succeeded",
 	},
+	"test-background-kill-invalid.md": {
+		ExpectedInStderr: "references a non-existent background process. Available background process indexes: [2]",
+	},
 }
 
 // ServerEndpointTestExpectations defines expectations for server_endpoint examples

--- a/examples/test-background-kill-invalid.md
+++ b/examples/test-background-kill-invalid.md
@@ -1,0 +1,28 @@
+# Test Invalid Background Kill Reference
+
+This test should fail because it references a non-background block.
+
+## Regular block (index 1)
+
+```bash
+echo "This is a regular block at index 1"
+```
+
+## Background block (index 2)
+
+```bash docci-background
+echo "This is a background block at index 2"
+sleep 10
+```
+
+## Another regular block (index 3)
+
+```bash
+echo "This is a regular block at index 3"
+```
+
+## Try to kill a non-background block (should fail)
+
+```bash docci-background-kill="1"
+echo "This should not execute"
+```

--- a/examples/test-background-kill-multiple.md
+++ b/examples/test-background-kill-multiple.md
@@ -1,0 +1,75 @@
+# Test Multiple Background Process Kill
+
+This example demonstrates killing specific background processes by index.
+
+## Start first background service
+
+```bash docci-background
+# Start a simple HTTP server on port 8081
+echo "Starting server 1 on port 8081"
+python3 -m http.server 8081
+```
+
+## Start second background service
+
+```bash docci-background
+# Start another HTTP server on port 8082
+echo "Starting server 2 on port 8082"
+python3 -m http.server 8082
+```
+
+## Verify both are running
+
+```bash
+echo "Checking both servers..."
+curl -s http://localhost:8081 > /dev/null && echo "Server 1 (port 8081) is running"
+curl -s http://localhost:8082 > /dev/null && echo "Server 2 (port 8082) is running"
+```
+
+## Kill only the first server
+
+```bash docci-background-kill="1"
+echo "Killed server 1, waiting for it to stop..."
+sleep 1
+```
+
+## Verify first is stopped, second still running
+
+```bash
+echo "Checking server status after killing server 1..."
+if curl -s http://localhost:8081 > /dev/null 2>&1; then
+  echo "ERROR: Server 1 is still running!"
+else
+  echo "SUCCESS: Server 1 has been stopped"
+fi
+
+if curl -s http://localhost:8082 > /dev/null 2>&1; then
+  echo "SUCCESS: Server 2 is still running"
+else
+  echo "ERROR: Server 2 was stopped (should still be running)"
+fi
+```
+
+## Kill the second server
+
+```bash docci-background-kill="2"
+echo "Now killing server 2..."
+sleep 1
+```
+
+## Verify both are stopped
+
+```bash
+echo "Final check - both servers should be stopped..."
+if curl -s http://localhost:8081 > /dev/null 2>&1; then
+  echo "ERROR: Server 1 is running!"
+else
+  echo "SUCCESS: Server 1 is stopped"
+fi
+
+if curl -s http://localhost:8082 > /dev/null 2>&1; then
+  echo "ERROR: Server 2 is running!"
+else
+  echo "SUCCESS: Server 2 is stopped"
+fi
+```


### PR DESCRIPTION
## Summary

Per a request from @Supeeerpower , adding support to stop a background during the runtime of the program

## Use case
- You start a server with a blocking process (anvil instance)
- You run your test
- You want to kill the original anvil instance and restart on the same port
- You specify to kill that background process at index so you can start a new anvil instance in the background

If you specify an index that is **not** a background process, it will error on run

markdown
````md
## Regular block (index 1)

```bash
echo "This is a regular block at index 1"
```

## Background block (index 2)

```bash docci-background
echo "This is a background block at index 2"
sleep 10
```

## Try to kill a non-background block (should fail because index is actually at 2)

```bash docci-background-kill="1"
echo "This should not execute"
```

````

```bash
docci run examples/test-background-kill-invalid.md

ERRO Failed to parse code blocks: block 4 (line 26): docci-background-kill=1 references a non-existent background process.
Available background process indexes: [2] 
ERRO Command failed with exit code: 1     
```

So the index is based on the actual location in the file. if you add new sections before the background process (a new codeblock) then the index would move up to 3 instead of 2. This is likely less confusing than doing it based on the index of the docci-background only blocks, but needs more input.